### PR TITLE
Update express base image

### DIFF
--- a/bedrock.hcl
+++ b/bedrock.hcl
@@ -2,7 +2,7 @@
 version = "1.0"
 
 serve {
-    image = "basisai/express-flask:v0.0.3"
+    image = "quay.io/basisai/express-flask:v0.0.5"
     install = [
         "pip install -r requirements.txt",
     ]
@@ -13,7 +13,7 @@ serve {
     ]
 
     parameters {
-        // This should be the name of python module that has a subclass of BaseModel 
+        // This should be the name of python module that has a subclass of BaseModel
         // https://github.com/basisai/bedrock-express#creating-a-model-server
         // If not specified as a parameter it defaults to "serve"
         BEDROCK_SERVER = "serve"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-bdrk[model-monitoring]==0.5.0
 numpy==1.19.2
 lightgbm==2.3.1


### PR DESCRIPTION
New version uses `boxkite==0.0.4`.

Tested locally
```bash
~/w/bedrock-express-churn-prediction (update|✔) $ curl -L tight-tree-9306.model.amoy.ai/predict -H "content-type: application/json" -d '{"State": "ME", "Area_Code": 408, "Intl_Plan": 1, "VMail_Plan": 0, "VMail_Message": 21, "CustServ_Calls": 4, "Day_Mins": 1, "Day_Calls": 1, "Eve_Mins": 15, "Eve_Calls": 5, "Night_Mins": 24, "Night_Calls": 2, "Intl_Mins": 8, "Intl_Calls": 1}'
{"prediction_id":"tight-tree-9306-d2dfd271/2021-04-23T09:56:30/64744bd2-e479-4786-82ff-a561318e873b","result":[0.9858616797204188]}
```